### PR TITLE
Bump CI to Node 22 and fix data ranker card hover text

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: ${{ steps.detect-package-manager.outputs.manager }}
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -75,6 +75,7 @@ const ProjectsPage = () => {
               subtitle="Upstash Redis | Game design"
               backgroundImage={dataFeatureRankerThumb}
               internalLink={"/data-feature-ranker"}
+              subtitleColour="white"
             />
             <ProjectCard
               title="Football tracker app"


### PR DESCRIPTION
## Summary
- Bump CI Node version from 20 to 22 (Node 20 actions deprecated June 16 2026)
- Add white subtitle colour to data feature ranker project card for readability on hover

## Test plan
- [ ] CI runs on Node 22 successfully
- [ ] Data ranker card subtitle is readable on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)