### PR TITLE
Fix cross-browser preview visibility and hover flicker

### DIFF
--- a/components/timingTower/TimingTower.tsx
+++ b/components/timingTower/TimingTower.tsx
@@ -9,7 +9,6 @@ interface TimingTowerProps {
   isIdle: boolean;
   onSelectItem: (id: string) => void;
   onHoverItem: (id: string) => void;
-  onMouseLeave: () => void;
 }
 
 const TimingTower: React.FC<TimingTowerProps> = ({
@@ -18,7 +17,6 @@ const TimingTower: React.FC<TimingTowerProps> = ({
   isIdle,
   onSelectItem,
   onHoverItem,
-  onMouseLeave,
 }) => {
   const activeItem = items.find((item) => item.id === activeItemId) ?? null;
 
@@ -52,7 +50,6 @@ const TimingTower: React.FC<TimingTowerProps> = ({
                 isLast={index === items.length - 1}
                 onSelect={onSelectItem}
                 onHover={onHoverItem}
-                onMouseLeave={onMouseLeave}
               />
               {/* Mobile inline preview — rendered after active row */}
               {activeItemId === item.id && (

--- a/components/timingTower/TimingTowerPreview.tsx
+++ b/components/timingTower/TimingTowerPreview.tsx
@@ -13,11 +13,12 @@ const TimingTowerPreview: React.FC<TimingTowerPreviewProps> = ({
   if (variant === 'desktop') {
     return (
       <div
-        className={`hidden md:block transition-all duration-500 ease-in-out ${
+        data-testid="desktop-preview"
+        className={`hidden md:block w-72 transition-all duration-500 ease-in-out ${
           item
-            ? 'opacity-100 translate-x-0 max-w-sm'
-            : 'opacity-0 -translate-x-4 max-w-0'
-        } overflow-hidden`}
+            ? 'opacity-100 translate-x-0'
+            : 'opacity-0 -translate-x-4 pointer-events-none'
+        }`}
       >
         {item && <PreviewContent item={item} />}
       </div>
@@ -27,6 +28,7 @@ const TimingTowerPreview: React.FC<TimingTowerPreviewProps> = ({
   // Mobile: inline accordion
   return (
     <div
+      data-testid="mobile-preview"
       className={`md:hidden transition-all duration-500 ease-in-out overflow-hidden ${
         item ? 'max-h-[300px] opacity-100' : 'max-h-0 opacity-0'
       }`}
@@ -39,8 +41,7 @@ const TimingTowerPreview: React.FC<TimingTowerPreviewProps> = ({
 const PreviewContent: React.FC<{ item: TimingTowerItem }> = ({ item }) => {
   return (
     <div
-      key={item.id}
-      className="bg-gray-300 md:bg-gray-300/70 md:backdrop-blur-xl border border-white/40 rounded-none md:rounded-xl p-2 md:p-4 animate-fadeIn w-full md:w-72"
+      className="bg-gray-300 md:bg-gray-300/70 md:backdrop-blur-xl border border-white/40 rounded-none md:rounded-xl p-2 md:p-4 w-full md:w-72"
     >
       {/* Thumbnail */}
       <div className="relative w-full aspect-video rounded-lg overflow-hidden shadow-sm">

--- a/components/timingTower/TimingTowerRow.tsx
+++ b/components/timingTower/TimingTowerRow.tsx
@@ -9,7 +9,6 @@ interface TimingTowerRowProps {
   isLast: boolean;
   onSelect: (id: string) => void;
   onHover: (id: string) => void;
-  onMouseLeave: () => void;
 }
 
 const TimingTowerRow: React.FC<TimingTowerRowProps> = ({
@@ -19,7 +18,6 @@ const TimingTowerRow: React.FC<TimingTowerRowProps> = ({
   isLast,
   onSelect,
   onHover,
-  onMouseLeave,
 }) => {
   const positionBg =
     item.position === 1
@@ -43,7 +41,6 @@ const TimingTowerRow: React.FC<TimingTowerRowProps> = ({
       className={`flex items-center gap-0 cursor-pointer transition-colors duration-300 ${rowBg} ${!isLast ? 'border-b border-white/10' : ''}`}
       onClick={() => onSelect(item.id)}
       onMouseEnter={() => onHover(item.id)}
-      onMouseLeave={onMouseLeave}
       onKeyDown={(e) => {
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault();

--- a/components/timingTower/TimingTowerSystem.tsx
+++ b/components/timingTower/TimingTowerSystem.tsx
@@ -144,7 +144,6 @@ const TimingTowerSystem: React.FC = () => {
           isIdle={isIdle}
           onSelectItem={handleSelectItem}
           onHoverItem={handleSelectItem}
-          onMouseLeave={handleMouseLeave}
         />
       </div>
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,44 +1,38 @@
-import { defineConfig } from '@playwright/test';
+import { defineConfig, devices } from '@playwright/test';
+
+const viewports = [
+  { name: 'mobile-portrait', width: 390, height: 844 },
+  { name: 'mobile-landscape', width: 844, height: 390 },
+  { name: 'desktop-small', width: 1280, height: 720 },
+  { name: 'desktop-large', width: 1920, height: 1080 },
+];
+
+const browsers = [
+  { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  { name: 'firefox', use: { ...devices['Desktop Firefox'] } },
+  { name: 'webkit', use: { ...devices['Desktop Safari'] } },
+];
 
 export default defineConfig({
   testDir: './tests',
   fullyParallel: true,
+  workers: process.env.CI ? undefined : 4,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   reporter: 'html',
   use: {
     baseURL: 'http://localhost:3000',
     trace: 'on-first-retry',
-    browserName: 'chromium',
   },
-  projects: [
-    {
-      name: 'mobile-portrait',
+  projects: viewports.flatMap((vp) =>
+    browsers.map((browser) => ({
+      name: `${vp.name}-${browser.name}`,
       use: {
-        viewport: { width: 390, height: 844 },
-        isMobile: true,
+        ...browser.use,
+        viewport: { width: vp.width, height: vp.height },
       },
-    },
-    {
-      name: 'mobile-landscape',
-      use: {
-        viewport: { width: 844, height: 390 },
-        isMobile: true,
-      },
-    },
-    {
-      name: 'desktop-small',
-      use: {
-        viewport: { width: 1280, height: 720 },
-      },
-    },
-    {
-      name: 'desktop-large',
-      use: {
-        viewport: { width: 1920, height: 1080 },
-      },
-    },
-  ],
+    }))
+  ),
   webServer: {
     command: 'npm run dev',
     url: 'http://localhost:3000',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -49,15 +49,6 @@ module.exports = {
           950: "#332015",
         },
       },
-      keyframes: {
-        fadeIn: {
-          from: { opacity: '0', transform: 'translateY(4px)' },
-          to: { opacity: '1', transform: 'translateY(0)' },
-        },
-      },
-      animation: {
-        fadeIn: 'fadeIn 0.3s ease-out',
-      },
     },
   },
   plugins: [],

--- a/tests/timing-tower.spec.ts
+++ b/tests/timing-tower.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from '@playwright/test';
+
+// Tailwind md: breakpoint — determines which preview variant renders
+const MD_BREAKPOINT = 768;
+
+test.describe('Timing tower preview visibility', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/', { waitUntil: 'networkidle' });
+    await page.waitForSelector('[role="button"]', { state: 'attached', timeout: 10000 });
+  });
+
+  test('clicking a row makes the preview panel visible with content', async ({ page }) => {
+    const { width } = page.viewportSize()!;
+    const isNarrow = width < MD_BREAKPOINT;
+
+    const firstRow = page.locator('[role="button"]').first();
+    await firstRow.click();
+    await page.waitForTimeout(600);
+
+    const testId = isNarrow ? 'mobile-preview' : 'desktop-preview';
+    const preview = page.getByTestId(testId);
+    await expect(preview).toBeVisible();
+
+    const box = await preview.boundingBox();
+    expect(box, 'preview should have a bounding box').not.toBeNull();
+    expect(box!.height, 'preview should have non-zero height').toBeGreaterThan(0);
+    expect(box!.width, 'preview should have non-zero width').toBeGreaterThan(isNarrow ? 0 : 10);
+  });
+
+  test('preview CTA link is visible and clickable', async ({ page }) => {
+    const { width } = page.viewportSize()!;
+    const testId = width < MD_BREAKPOINT ? 'mobile-preview' : 'desktop-preview';
+
+    const firstRow = page.locator('[role="button"]').first();
+    await firstRow.click();
+    await page.waitForTimeout(600);
+
+    const preview = page.getByTestId(testId);
+    const cta = preview.locator('a').filter({ hasText: /View Project|Read on Get Goalside/ });
+
+    await expect(cta).toBeVisible();
+
+    const ctaBox = await cta.boundingBox();
+    expect(ctaBox, 'CTA should have a bounding box').not.toBeNull();
+    expect(ctaBox!.height, 'CTA should have non-zero height').toBeGreaterThan(0);
+    expect(ctaBox!.width, 'CTA should have non-zero width').toBeGreaterThan(0);
+  });
+
+  test('preview description text is visible', async ({ page }) => {
+    const { width } = page.viewportSize()!;
+    const testId = width < MD_BREAKPOINT ? 'mobile-preview' : 'desktop-preview';
+
+    const firstRow = page.locator('[role="button"]').first();
+    await firstRow.click();
+    await page.waitForTimeout(600);
+
+    const preview = page.getByTestId(testId);
+    const description = preview.locator('p').first();
+
+    await expect(description).toBeVisible();
+
+    const descBox = await description.boundingBox();
+    expect(descBox, 'description should have a bounding box').not.toBeNull();
+    expect(descBox!.height, 'description should have non-zero height').toBeGreaterThan(0);
+  });
+
+  test('preview thumbnail image is visible', async ({ page }) => {
+    const { width } = page.viewportSize()!;
+    const testId = width < MD_BREAKPOINT ? 'mobile-preview' : 'desktop-preview';
+
+    const firstRow = page.locator('[role="button"]').first();
+    await firstRow.click();
+    await page.waitForTimeout(600);
+
+    const preview = page.getByTestId(testId);
+    const img = preview.locator('img');
+
+    await expect(img).toBeVisible();
+
+    const imgBox = await img.boundingBox();
+    expect(imgBox, 'thumbnail should have a bounding box').not.toBeNull();
+    expect(imgBox!.height, 'thumbnail should have non-zero height').toBeGreaterThan(0);
+    expect(imgBox!.width, 'thumbnail should have non-zero width').toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

- **Fix preview flicker**: Removed `key={item.id}` from the preview panel, which was forcing React to unmount/remount (and re-trigger a fadeIn animation) on every item change. Content now swaps in place without flashing.
- **Fix fragile visibility mechanism**: Replaced `overflow-hidden` + `max-w-0`/`max-w-sm` width transition with fixed `w-72` + opacity/pointer-events. The old approach relied on overflow clipping during max-width transitions, which rendered the preview invisible on Zen browser (macOS).
- **Cross-browser tests**: Playwright now runs across Chromium, Firefox, and WebKit. New tests verify the preview panel, CTA link, description, and thumbnail are all visible after clicking a timing tower row.
- **Cleanup**: Removed redundant per-row `onMouseLeave` handlers (container-level handler suffices) and unused fadeIn keyframe/animation config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)